### PR TITLE
CFP/diversity/accessibility pages

### DIFF
--- a/content/cfp.html
+++ b/content/cfp.html
@@ -3,9 +3,7 @@ title: Call for Proposals
 slug: cfp
 body_class_hack: talks
 ---
-<h2>Call for proposals</h2>
-
-<h3>We want proposals from...</h3>
+<h2>We want proposals from...</h2>
 <em>You.</em>
 
 <p>This is a <strong>community conference</strong>. You’re coming to the event, and that makes <strong>you</strong> part of the community and makes this <strong>your</strong> conference. If you’ve done something that you think other people might be interested in, or that you think they should know about, <em>we would love to know about it</em>.</p>
@@ -14,69 +12,72 @@ body_class_hack: talks
 
 <p>Note that there is a <a href="#financial-support">programme of financial support</a> for speakers.</p>
 
-<h3>We <em>especially</em> want proposals from...</h3>
+<h2>We <em>especially</em> want proposals from...</h2>
 
 <em>People who are minorities in this field</em>
-<p><a href="/diversity-accessibility">Diversity at PyCon</a> is important to us.</p>
+<p><a href="/diversity-accessibility">Diversity at PyCon UK</a> is important to us. We want the conference to represent our community better and in turn to help make the community more inclusive.</p>
 
-<p>If you can help us make this event more diverse just by being there, please, do come forward with a proposal. We need you.</p>
+<p>Please do come forward with a proposal. We can't succeed in this without your participation.</p>
 
 <em>First-time speakers</em>
-<p>If you haven’t spoken at a conference before, this is your invitation to do so. After all, we want to be remembered as the conference where you started your superstar speaking career. You’ll find that a Python/Django audience is friendly and receptive, so don’t be shy.</p>
+<p>If you haven’t spoken at a conference before, this is your invitation to do so. After all, we want to be remembered as the conference where you started your superstar speaking career. You’ll find that a Python audience is friendly and receptive, so don’t be shy.</p>
 
 <strong>If you’d like any help in proposing, preparing or presenting your talk, whoever you are and whatever kind of help you’d find useful: please see our <a href="/speaker-mentors">speaker mentor programme</a>.</strong>
 
-<h3>Propose a...</h3>
+<h2>Propose a...</h2>
 
-<h4>Talk</h4>
+<h3>Talk</h3>
 <p>Do you have something to share with the rest of the community?</p>
 
 <p>Proposals on any subject are welcomed, at any level of technical expertise.</p>
 
 <p>Tell us about your experiments, discoveries, solutions, achievements and other adventures, using the talk proposal form.</p>
 
-<h5>Lightning talks</h5>
+<h4>Lightning talks</h4>
 
 <p>There’ll also be opportunities for five-minute lightning talks. You don’t need to register in advance; just put your name down on the day.</p>
 
-<h4>Workshop</h4>
-<p>Can you lead a tutorial, on a Python or Django topic?</p>
+<h3>Workshop</h3>
+<p>Can you lead a tutorial, on any Python or related topic?</p>
 
-<p>We’ll be holding introductory workshops on our open day, and more advanced sessions alongside the sprints on Thursday and Friday.</p>
+<p>We’ll be holding workshops aimed at different levels of technical expertise.</p>
 
 <p>Please don’t hesitate to suggest a workshop for the event, using the workshop proposal form. We’re open to all kinds of ideas, and especially ones we haven’t even thought of.</p>
 
-<h4>Code clinic</h4>
+<h3>Code clinic</h3>
 <p>Could you be a friendly neighbourhood code doctor?</p>
 
-<p>Alongside the sprints, we’re holding code clinics, where an expert will be on hand to help with people’s Python/Django questions and problems.</p>
+<p>Alongside the sprints, we’re holding code clinics, where an expert will be on hand to help with people’s Python questions and problems.</p>
 
 <p>A clinic might run for an hour or two. If you like to offer a clinic on a particular subject, or even a general one, please use the workshop proposal form.</p>
 
-<h3>How to submit a proposal</h3>
+<h3>Lunchtime event</h3>
+<p>Lunchtime gatherings for a discussion or demonstration.</p>
+
+<h2>How to submit a proposal</h2>
 <p>There’s a proposal form for talks and a proposal form for tutorials and demonstrations. Take a look at them - they’ll make it clearer how this works.</p>
 
 <p>Don’t agonise over your proposal. Just get it in. We’ll get back to you if anything’s not clear.</p>
 
 <p>Don’t hesitate to submit more than one proposal.</p>
 
-<p>The deadline for submissions is the end of 10th May (UTC).</p>
+<p>The deadline for submissions is the end of Wednesday 15th June (UTC).</p>
 
-<h3>Need help?</h3>
+<h2>Need help?</h2>
 <p>Perhaps you’re not sure what aspect of your proposed subject will be most appropriate or interesting, or how to word it, or what level to pitch it at. Perhaps you’re not sure it’s what we’re looking for.</p>
 
 <p>That’s OK. In fact, we have a <a href="/speaker-mentors">speaker mentor programme</a> in place to help you.</p>
 
 <p>If there’s anything we can do that would make it easier for you to submit a proposal, just get in touch. We want to help.</p>
 
-<h4>How we'll choose</h4>
+<h3>How we'll choose</h3>
 <p>We’re going to choose a selection of talks, tutorials and demonstrations that we feel add up to the most enjoyable and interesting programme for our attendees.</p>
 
 <p>We won’t just be choosing the ones from the most expert speakers, or even the most exciting subjects, because we need to have a good balance as well.</p>
 
 <p>We’ll publish the list of selected talks as soon as we can after the deadline.</p>
 
-<h3 id="financial-support">Financial support for speakers</h3>
+<h2 id="financial-support">Financial support for speakers</h2>
 <p>Grants to assist speakers on low budgets will be available, as well as free and discounted tickets. They'll be allocated by the committee. Any speaker who needs help will receive it. Apply for a grant until the end of 10th May.</p>
 
 <p>The grants committee will be especially interested in receiving applications from people belonging to under-represented demographic groups.</p>

--- a/content/cfp.html
+++ b/content/cfp.html
@@ -54,6 +54,9 @@ body_class_hack: talks
 <h3>Lunchtime event</h3>
 <p>Lunchtime gatherings for a discussion or demonstration.</p>
 
+<h3>Poster</h3>
+<p>Describe your work/thoughts/plans on a large poster, and discuss it with visitors.</p>
+
 <h2>How to submit a proposal</h2>
 <p>There’s a proposal form for talks and a proposal form for tutorials and demonstrations. Take a look at them - they’ll make it clearer how this works.</p>
 

--- a/content/cfp.html
+++ b/content/cfp.html
@@ -1,0 +1,82 @@
+type: page
+title: Call for Proposals
+slug: cfp
+body_class_hack: talks
+---
+<h2>Call for proposals</h2>
+
+<h3>We want proposals from...</h3>
+<em>You.</em>
+
+<p>This is a <strong>community conference</strong>. You’re coming to the event, and that makes <strong>you</strong> part of the community and makes this <strong>your</strong> conference. If you’ve done something that you think other people might be interested in, or that you think they should know about, <em>we would love to know about it</em>.</p>
+
+<p>We <strong>don’t</strong> just want to hear from the experts or famous names - other perspectives are just as valuable, so don’t let the idea that you’re not expert or famous enough stop you because <em>this won’t stop us from selecting your talk or the audience from enjoying it</em>.</p>
+
+<p>Note that there is a <a href="#financial-support">programme of financial support</a> for speakers.</p>
+
+<h3>We <em>especially</em> want proposals from...</h3>
+
+<em>People who are minorities in this field</em>
+<p><a href="/diversity-accessibility">Diversity at PyCon</a> is important to us.</p>
+
+<p>If you can help us make this event more diverse just by being there, please, do come forward with a proposal. We need you.</p>
+
+<em>First-time speakers</em>
+<p>If you haven’t spoken at a conference before, this is your invitation to do so. After all, we want to be remembered as the conference where you started your superstar speaking career. You’ll find that a Python/Django audience is friendly and receptive, so don’t be shy.</p>
+
+<strong>If you’d like any help in proposing, preparing or presenting your talk, whoever you are and whatever kind of help you’d find useful: please see our <a href="/speaker-mentors">speaker mentor programme</a>.</strong>
+
+<h3>Propose a...</h3>
+
+<h4>Talk</h4>
+<p>Do you have something to share with the rest of the community?</p>
+
+<p>Proposals on any subject are welcomed, at any level of technical expertise.</p>
+
+<p>Tell us about your experiments, discoveries, solutions, achievements and other adventures, using the talk proposal form.</p>
+
+<h5>Lightning talks</h5>
+
+<p>There’ll also be opportunities for five-minute lightning talks. You don’t need to register in advance; just put your name down on the day.</p>
+
+<h4>Workshop</h4>
+<p>Can you lead a tutorial, on a Python or Django topic?</p>
+
+<p>We’ll be holding introductory workshops on our open day, and more advanced sessions alongside the sprints on Thursday and Friday.</p>
+
+<p>Please don’t hesitate to suggest a workshop for the event, using the workshop proposal form. We’re open to all kinds of ideas, and especially ones we haven’t even thought of.</p>
+
+<h4>Code clinic</h4>
+<p>Could you be a friendly neighbourhood code doctor?</p>
+
+<p>Alongside the sprints, we’re holding code clinics, where an expert will be on hand to help with people’s Python/Django questions and problems.</p>
+
+<p>A clinic might run for an hour or two. If you like to offer a clinic on a particular subject, or even a general one, please use the workshop proposal form.</p>
+
+<h3>How to submit a proposal</h3>
+<p>There’s a proposal form for talks and a proposal form for tutorials and demonstrations. Take a look at them - they’ll make it clearer how this works.</p>
+
+<p>Don’t agonise over your proposal. Just get it in. We’ll get back to you if anything’s not clear.</p>
+
+<p>Don’t hesitate to submit more than one proposal.</p>
+
+<p>The deadline for submissions is the end of 10th May (UTC).</p>
+
+<h3>Need help?</h3>
+<p>Perhaps you’re not sure what aspect of your proposed subject will be most appropriate or interesting, or how to word it, or what level to pitch it at. Perhaps you’re not sure it’s what we’re looking for.</p>
+
+<p>That’s OK. In fact, we have a <a href="/speaker-mentors">speaker mentor programme</a> in place to help you.</p>
+
+<p>If there’s anything we can do that would make it easier for you to submit a proposal, just get in touch. We want to help.</p>
+
+<h4>How we'll choose</h4>
+<p>We’re going to choose a selection of talks, tutorials and demonstrations that we feel add up to the most enjoyable and interesting programme for our attendees.</p>
+
+<p>We won’t just be choosing the ones from the most expert speakers, or even the most exciting subjects, because we need to have a good balance as well.</p>
+
+<p>We’ll publish the list of selected talks as soon as we can after the deadline.</p>
+
+<h3 id="financial-support">Financial support for speakers</h3>
+<p>Grants to assist speakers on low budgets will be available, as well as free and discounted tickets. They'll be allocated by the committee. Any speaker who needs help will receive it. Apply for a grant until the end of 10th May.</p>
+
+<p>The grants committee will be especially interested in receiving applications from people belonging to under-represented demographic groups.</p>

--- a/content/diversity-accessibility.html
+++ b/content/diversity-accessibility.html
@@ -3,45 +3,43 @@ title: Diversity and accessibility
 slug: diversity-accessibility
 body_class_hack: talks
 ---
-<h2>Diversity and accessibility at PyCon UK</h2>
-
 <p>Most of the global software industry is dominated by a very narrow demographic, of young, white, western men. This imbalance isn't good for anyone, and we want PyCon UK 2016 to be a milestone in the effort to address it.</p>
 
 <p>We will be making every effort to hold as inclusive an event as possible, and to shift the demographic of our audience and speakers. This is not just a vague aim, <a href="/news/target">it's a clear target</a>.</p>
 
-<h3>Code of conduct</h3>
-<p>Like every PyCon, we have a prominent <a href="/codeofconduct">code of conduct</a> <strong>that will be enforced</strong>.</p>
+<h2>Code of conduct</h2>
+<p>Like every PyCon, we have a prominent <a href="/code-of-conduct">code of conduct</a> <strong>that will be enforced</strong>.</p>
 
-<h3>Minorities in our community</h3>
+<h2>Minorities in our community</h2>
 <p>It’s not simply iniquitous that the minorities of our community - for example, women, people of non-European descent, people with disabilities - find it harder to participate in it: their participation is vital to its health and needed now more than ever.</p>
 
-<p>If you belong to one of these or any other under-represented groups, we’re especially keen to have you at PyCon. We want to help redress the imbalance, make a clear statement about your value to the community affirm your position as a first-class citizen of it.</p>
+<p>If you belong to one of these or any other under-represented groups, we’re especially keen to have you at PyCon. We want to help redress the imbalance, make a clear statement about your value to the community and affirm your position as a first-class citizen of it.</p>
 
 
-<h3>Django Girls</h3>
+<h2>Django Girls</h2>
 <p>There'll be a day-long <a href="/djangogirls">Django Girls workshop</a> at PyCon. Since the first DjangoGirls event in July 2014, hundreds of women have been introduced to Django and Python through these free workshops.</p>
 
 <p>We are offering a number of free conference tickets for PyCon to DjangoGirls attendees. These are full tickets, and include meals, refreshments and everything else that the conference has to offer.</p>
 
 <p>Both the DjangoGirls workshop and the ticket offer will be oversubscribed; places and tickets will be allocated by the Django Girls organisers.</p>
 
-<h3>Trans*Code</h3>
+<h2>Trans*Code</h2>
 <p><a href="/transcode">Trans*Code</a> will be running a hackday at the event.</p>
 
 <p>The Trans*Code event is an opportunity to work with others on projects and issues that particularly affect the trans community.</p>
 
-<h3>Financial assistance</h3>
+<h2>Financial assistance</h2>
 <p>We will be supporting individuals who need help to meet the costs of travel, subsistence or even taking days off work. This will include discounted or free conference tickets. <em>Speakers will automatically be eligible for this assistance if they require it.</em></p>
 
-<h4>Apply for financial assistance</h4>
+<h3>Apply for financial assistance</h3>
 <p>We have set aside a considerable sum for financial assistance.</p>
 
 <p><em>Don't be reluctant to apply for financial assistance.</em> Many of your fellow speakers and some members of the committee will be doing the same. The money is there to help <strong>you</strong>.</p>
 
-<h3>Supporter tickets</h3>
-<p>We have made <em>Diversity supporter tickets</em> available. As well as your own ticket, you can buy a ticket on behalf of an attendee who couldn’t otherwise afford it. These tickets will be allocated by an awards committee, and you or your organisation will be - unless you state otherwise - thanked publicly for your generous support.</p>
+<h2>Supporter tickets</h2>
+<p>We have made <em>Supporter tickets</em> available. As well as your own ticket, you can buy a ticket on behalf of an attendee who couldn’t otherwise afford it. These tickets will be allocated by an awards committee, and you or your organisation will be - unless you state otherwise - thanked publicly for your generous support.</p>
 
-<h3>Mobility</h3>
+<h2>Mobility</h2>
 
 <p>The PyCon venue is fully <strong>wheelchair-accessible</strong> and has:</p>
 
@@ -51,24 +49,24 @@ body_class_hack: talks
 <li>toilets suitable for wheelchair users</li>
 </ul>
 
-<p>Please contact us about any mobility assistance needs you may have during your stay in Cardiff.</p>
+<p>Please <a href="/contact">contact us</a> about any mobility assistance needs you may have during your stay in Cardiff.</p>
 
-<h3>Visual impairments</h3>
+<h2>Visual impairments</h2>
 <p><strong>Preferred seating</strong> will be provided and reserved for the visually-impaired. Please contact us about any lighting requirements you may have, and we will do our best to meet them.</p>
 
 <p>Similarly, if you would benefit from having a <strong>close-up display of presenters’ slides and screens</strong>, or from the provision of any <strong>assistive technology</strong>, just let us know.</p>
 <p><strong>Guide dogs</strong> are welcome at the conference and social events.</p>
 
-<h3>Hearing impairments</h3>
+<h2>Hearing impairments</h2>
 <p>All talks will be held in auditoriums with <strong>induction loops for hearing aid users</strong>.</p>
 
 <p>In addition, talks will feature <strong>simultaneous speech-to-text transcription</strong>, which will also be used for subtitling the conference videos that are subsequently published.</p>
 
 <p>On request, we will provide a British Sign Language interpreter (at no charge) for the duration of the conference to any Deaf attendees, to help them participate more fully in discussions and social events.</p>
 
-<p>Please note that while BSL shares significant similarity with Auslan and New Zealand Sign Language, it is quite distinct from American Sign Language. However, we will do our best to meet any request for other sign language interpreters - so please just ask.</p>
+<p>Please note that while BSL shares significant similarity with Auslan and New Zealand Sign Language, it is quite distinct from American Sign Language. However, we will do our best to meet any request for other sign language interpreters - <a href="/contact">so please just ask</a>.</p>
 
-<h3>Crèche</h3>
+<h2>Crèche</h2>
 <p>We will provide a <strong>free crèche</strong>, staffed by registered and qualified childminders, during conference hours.</p>
 
 <p>You will need to register well in advance for the crèche.</p>
@@ -79,14 +77,14 @@ body_class_hack: talks
 
 <p>If they are not, you will need to provide their food.</p>
 
-<h4>Breastfeeding at PyCon</h4>
+<h3>Breastfeeding at PyCon</h3>
 <p>If you are breastfeeding your baby, we can provide a quiet room <strong>if that’s what you prefer</strong>. Otherwise, <strong>please feed your baby whenever and wherever you like</strong>, including during talks and at meal-times. PyCon will be a friendly environment for parents and babies.</p>
 
-<h3>Dietary requirements</h3>
+<h2>Dietary requirements</h2>
 <p>We aim to meet <strong>all dietary requirements</strong>. You will be able to specify these when purchasing your ticket.</p>
 
-<h3>Quiet room</h3>
+<h2>Quiet room</h2>
 <p>We will provide a clearly-marked designated quiet room at all venues. This room is intended to be a calm and quiet place for anyone who needs to have a break from the bustle of the conference, and will not be used for socialising.</p>
 
-<h3>Is something missing?</h3>
-<p>Have we neglected something you need, or is there something not mentioned here that would make your attendance possible, or improve your experience of the event? Please let us know. We’ll do what can to provide it.</p>
+<h2>Is something missing?</h2>
+<p>Have we neglected something you need, or is there something not mentioned here that would make your attendance possible, or improve your experience of the event? <a href="/contact">Please let us know</a>. We’ll do what can to provide it.</p>

--- a/content/diversity-accessibility.html
+++ b/content/diversity-accessibility.html
@@ -1,6 +1,6 @@
 type: page
-title: Diversity and accessibility
-slug: diversity-accessibility
+title: Diversity, accessibility, inclusion
+slug: diversity-accessibility-inclusion
 body_class_hack: talks
 ---
 <p>Most of the global software industry is dominated by a very narrow demographic, of young, white, western men. This imbalance isn't good for anyone, and we want PyCon UK 2016 to be a milestone in the effort to address it.</p>

--- a/content/diversity-accessibility.html
+++ b/content/diversity-accessibility.html
@@ -1,0 +1,92 @@
+type: page
+title: Diversity and accessibility
+slug: diversity-accessibility
+body_class_hack: talks
+---
+<h2>Diversity and accessibility at PyCon UK</h2>
+
+<p>Most of the global software industry is dominated by a very narrow demographic, of young, white, western men. This imbalance isn't good for anyone, and we want PyCon UK 2016 to be a milestone in the effort to address it.</p>
+
+<p>We will be making every effort to hold as inclusive an event as possible, and to shift the demographic of our audience and speakers. This is not just a vague aim, <a href="/news/target">it's a clear target</a>.</p>
+
+<h3>Code of conduct</h3>
+<p>Like every PyCon, we have a prominent <a href="/codeofconduct">code of conduct</a> <strong>that will be enforced</strong>.</p>
+
+<h3>Minorities in our community</h3>
+<p>It’s not simply iniquitous that the minorities of our community - for example, women, people of non-European descent, people with disabilities - find it harder to participate in it: their participation is vital to its health and needed now more than ever.</p>
+
+<p>If you belong to one of these or any other under-represented groups, we’re especially keen to have you at PyCon. We want to help redress the imbalance, make a clear statement about your value to the community affirm your position as a first-class citizen of it.</p>
+
+
+<h3>Django Girls</h3>
+<p>There'll be a day-long <a href="/djangogirls">Django Girls workshop</a> at PyCon. Since the first DjangoGirls event in July 2014, hundreds of women have been introduced to Django and Python through these free workshops.</p>
+
+<p>We are offering a number of free conference tickets for PyCon to DjangoGirls attendees. These are full tickets, and include meals, refreshments and everything else that the conference has to offer.</p>
+
+<p>Both the DjangoGirls workshop and the ticket offer will be oversubscribed; places and tickets will be allocated by the Django Girls organisers.</p>
+
+<h3>Trans*Code</h3>
+<p><a href="/transcode">Trans*Code</a> will be running a hackday at the event.</p>
+
+<p>The Trans*Code event is an opportunity to work with others on projects and issues that particularly affect the trans community.</p>
+
+<h3>Financial assistance</h3>
+<p>We will be supporting individuals who need help to meet the costs of travel, subsistence or even taking days off work. This will include discounted or free conference tickets. <em>Speakers will automatically be eligible for this assistance if they require it.</em></p>
+
+<h4>Apply for financial assistance</h4>
+<p>We have set aside a considerable sum for financial assistance.</p>
+
+<p><em>Don't be reluctant to apply for financial assistance.</em> Many of your fellow speakers and some members of the committee will be doing the same. The money is there to help <strong>you</strong>.</p>
+
+<h3>Supporter tickets</h3>
+<p>We have made <em>Diversity supporter tickets</em> available. As well as your own ticket, you can buy a ticket on behalf of an attendee who couldn’t otherwise afford it. These tickets will be allocated by an awards committee, and you or your organisation will be - unless you state otherwise - thanked publicly for your generous support.</p>
+
+<h3>Mobility</h3>
+
+<p>The PyCon venue is fully <strong>wheelchair-accessible</strong> and has:</p>
+
+<ul>
+<li>step-free access from the street and car-parks</li>
+<li>step-free access to all auditoriums, theatres and halls</li>
+<li>toilets suitable for wheelchair users</li>
+</ul>
+
+<p>Please contact us about any mobility assistance needs you may have during your stay in Cardiff.</p>
+
+<h3>Visual impairments</h3>
+<p><strong>Preferred seating</strong> will be provided and reserved for the visually-impaired. Please contact us about any lighting requirements you may have, and we will do our best to meet them.</p>
+
+<p>Similarly, if you would benefit from having a <strong>close-up display of presenters’ slides and screens</strong>, or from the provision of any <strong>assistive technology</strong>, just let us know.</p>
+<p><strong>Guide dogs</strong> are welcome at the conference and social events.</p>
+
+<h3>Hearing impairments</h3>
+<p>All talks will be held in auditoriums with <strong>induction loops for hearing aid users</strong>.</p>
+
+<p>In addition, talks will feature <strong>simultaneous speech-to-text transcription</strong>, which will also be used for subtitling the conference videos that are subsequently published.</p>
+
+<p>On request, we will provide a British Sign Language interpreter (at no charge) for the duration of the conference to any Deaf attendees, to help them participate more fully in discussions and social events.</p>
+
+<p>Please note that while BSL shares significant similarity with Auslan and New Zealand Sign Language, it is quite distinct from American Sign Language. However, we will do our best to meet any request for other sign language interpreters - so please just ask.</p>
+
+<h3>Crèche</h3>
+<p>We will provide a <strong>free crèche</strong>, staffed by registered and qualified childminders, during conference hours.</p>
+
+<p>You will need to register well in advance for the crèche.</p>
+
+<p>Children will be welcome at all appropriate conference events, during breaks for refreshments <em>and in the audience at talks</em>.</p>
+
+<p>If your child is old enough to have meals and refreshments with us, they are welcome to join us.</p>
+
+<p>If they are not, you will need to provide their food.</p>
+
+<h4>Breastfeeding at PyCon</h4>
+<p>If you are breastfeeding your baby, we can provide a quiet room <strong>if that’s what you prefer</strong>. Otherwise, <strong>please feed your baby whenever and wherever you like</strong>, including during talks and at meal-times. PyCon will be a friendly environment for parents and babies.</p>
+
+<h3>Dietary requirements</h3>
+<p>We aim to meet <strong>all dietary requirements</strong>. You will be able to specify these when purchasing your ticket.</p>
+
+<h3>Quiet room</h3>
+<p>We will provide a clearly-marked designated quiet room at all venues. This room is intended to be a calm and quiet place for anyone who needs to have a break from the bustle of the conference, and will not be used for socialising.</p>
+
+<h3>Is something missing?</h3>
+<p>Have we neglected something you need, or is there something not mentioned here that would make your attendance possible, or improve your experience of the event? Please let us know. We’ll do what can to provide it.</p>

--- a/content/news/target.html
+++ b/content/news/target.html
@@ -1,0 +1,52 @@
+type: page
+title: Target
+slug: target
+body_class_hack: education
+---
+
+<h2>Our diversity target</h2>
+
+<p>We want this year's PyCon audience to be the most diverse ever, and the conference to represent the diversity of their experiences and interests.</p>
+
+<p>To help us achieve this, we have set ourselves some aims, and one very clear and simple target.</p>
+
+<p>It's notable how few women there are typically in attendance at a software conference. It's not just women who are sorely under-represented at software events, it's also non-white people, older people, disabled people and other groups too.</p>
+
+<p>There are many metrics for diversity, but in the interests of simplicity and practicality as far as targets and recorded numbers are concerned, at this event we'll be focusing particularly on the gender balance of our audience and speakers.</p>
+
+<h3>Speaker diversity</h3>
+
+<p>At last year's event, <strong>fewer than 20%</strong> of our speakers were women. That's even even lower than the proportion of women MPs in the House of Commons.</p>
+
+<p>It doesn't have to be this way. Our target at this PyCon is to receive at least **one-third of our talk proposals from women**, and a substantial improvement generally in the representation of other PyCon minorities amongst the talk applicants.</p>
+
+<p>This is not impossible to achieve, by any means.</p>
+
+<h4>PyCon US</h4>
+
+<ul>
+<li>2011: about 1% of speakers were women</li>
+<li>2014 and 2015: about one-third were women</li>
+</ul>
+
+<h4>DjangoCon Europe</h4>
+
+<ul>
+<li>2014: two our of 32 speakers were women</li>
+<li>2105: approximately one-third of speakers were women</li>
+<li>2016: approximately one-half of speakers are women</li>
+</ul>
+
+<p>(It's less easy to put numbers to other under-represented groups.)</p>
+
+<h3>How we intend to meet this target</h3>
+
+<p>To achieve the numbers we're aiming for, we will encourage people in under-represented groups to submit more talks.</p>
+
+<p>This will involve a number of different initiatives and strategies, that have proved successful in at other events. To begin with, you can read more about our <a href="/diversity-accessibility">diversity and accessibility policies</a>.</p>
+
+<p>We will be monitoring our own progress, and reporting on it.</p>
+
+<p>In the meantime, if you're a Python user who's in one of the many groups that are not well-represented at our PyCons, we particularly want to hear from you, and we urge you to consider <a href="/cfp">submitting a proposal</a> for a talk, workshop or other activity.</p>
+
+<p>Thanks!</p>

--- a/content/speaker-mentors.html
+++ b/content/speaker-mentors.html
@@ -7,7 +7,9 @@ body_class_hack: talks
 
 <p>For first-time speakers, non-native English speakers, unconfident or uncertain speakers or simply anyone who’d like some help with a talk - here are some people who’d like to help you.</p>
 
-<p>Speaking in front of a large audience doesn’t come easily to many people. Our conference audiences are full of <em>interesting people with interesting things to say</em> - who remain in the audience because for whatever reason, they didn’t feel confident enough to submit a talk proposal.</p>
+<p>Speaking in front of a large audience doesn’t come easily to many people. Our conference
+audiences are full of <em>interesting people with interesting things to say</em>. We want more of
+them to to feel confident enough to submit a talk proposal.</p>
 
 <p>We know those people exist, because we meet them at every event, and it’s always a shame to discover that someone had an interesting talk in them but kept it there.</p>
 

--- a/content/speaker-mentors.html
+++ b/content/speaker-mentors.html
@@ -1,0 +1,24 @@
+type: page
+title: Speaker mentor programme
+slug: speaker-mentors
+body_class_hack: talks
+---
+<h2>Speaker mentors at PyCon UK</h2>
+
+<p>For first-time speakers, non-native English speakers, unconfident or uncertain speakers or simply anyone who’d like some help with a talk - here are some people who’d like to help you.</p>
+
+<p>Speaking in front of a large audience doesn’t come easily to many people. Our conference audiences are full of <em>interesting people with interesting things to say</em> - who remain in the audience because for whatever reason, they didn’t feel confident enough to submit a talk proposal.</p>
+
+<p>We know those people exist, because we meet them at every event, and it’s always a shame to discover that someone had an interesting talk in them but kept it there.</p>
+
+<h3>How the programme works</h3>
+<p>To help more people feel comfortable taking the step to submit a talk, we have a <strong>speaker mentor programme</strong>. A speaker mentor is an experienced speaker, who has volunteered to help other speakers.</p>
+
+<p>It could be any kind of help, for any kind of reason: anything from someone who can advise on whether your idea for a talk is a good one to someone who’ll be happy to hear you practise it; even someone who’ll agree to be the session chair for your talk at the event. You tell us what kind of help you’d like.</p>
+
+<p>And it could be because you’re not confident about your English, because you’re a nervous speaker, because you’ve never done a talk before - it doesn’t matter why, the point is that if you’d like help, we can put you in touch with someone suitable to help you.</p>
+
+<p>If you’d particularly like a speaker mentor who’s familiar with a particular subject, who speaks your native language, a female mentor - again, just tell us what will help you.</p>
+
+<p><strong>Remember, we don’t want to be proud because we had a lot of superstar speakers at our conference. We want to be proud because we were the conference where you began your superstar speaking career.</strong></p>
+

--- a/templates/base.html
+++ b/templates/base.html
@@ -27,9 +27,6 @@
                         <li class="halfway"><a {% if page.title == "Contact" %} class="active"{% endif %}href="/contact/">Contact</a></li>
                         <li><a {% if page.title == "Sponsorship" %} class="active"{% endif %}href="/sponsorship/">Sponsor</a></li>
                         <li><a {% if page.title == "Registration" %} class="active"{% endif %}href="/register/">Register</a></li>
-                        <li><a {% if page.title == "Call for proposals" %} class="active"{% endif %}href="/cfp/">Call for proposals</a></li>
-                        <li><a {% if page.title == "Diversity & accessibility" %} class="active"{% endif %}href="/diversity-accessibility/">Diversity & accessibility</a></li>
-                        <li><a {% if page.title == "Speaker mentors" %} class="active"{% endif %}href="/speaker-mentors/">Speaker mentors</a></li>
                     </ul>
                 </nav>
             </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -23,10 +23,13 @@
                     <ul>
                         <li><a {% if page.title == "Programme" %} class="active"{% endif %}href="/programme/">Programme</a></li>
                         <li><a {% if page.title == "Venue" %} class="active"{% endif %}href="/venue/">Venue</a></li>
-                        <li><a {% if page.title == "Code Of Conduct" %} class="active"{% endif %}href="/code-of-conduct/">Conduct</a></li>
+                        <li><a {% if page.title == "Code Of Conduct" %} class="active"{% endif %}href="/code-of-conduct/">Code of Conduct</a></li>
                         <li class="halfway"><a {% if page.title == "Contact" %} class="active"{% endif %}href="/contact/">Contact</a></li>
                         <li><a {% if page.title == "Sponsorship" %} class="active"{% endif %}href="/sponsorship/">Sponsor</a></li>
                         <li><a {% if page.title == "Registration" %} class="active"{% endif %}href="/register/">Register</a></li>
+                        <li><a {% if page.title == "Call for proposals" %} class="active"{% endif %}href="/cfp/">Call for proposals</a></li>
+                        <li><a {% if page.title == "Diversity & accessibility" %} class="active"{% endif %}href="/diversity-accessibility/">Diversity & accessibility</a></li>
+                        <li><a {% if page.title == "Speaker mentors" %} class="active"{% endif %}href="/speaker-mentors/">Speaker mentors</a></li>
                     </ul>
                 </nav>
             </div>
@@ -42,5 +45,5 @@
 
     </body>
 
-    <!-- Python Powered! --> 
+    <!-- Python Powered! -->
 </html>


### PR DESCRIPTION
- added a call for proposals page `/cfp`
- added a speaker mentors page `speaker-mentors`
- added a diversity/accessibility page `/diversity-accessibility`
- added a news section with a news article `/news/target` (I have no idea how to implement this btw)
- aded items to the menu in the base template, making a big mess of it
