### PR TITLE
Add blurb for research theme.

### DIFF
--- a/content/code4research.md
+++ b/content/code4research.md
@@ -1,0 +1,24 @@
+type: page
+title: Code4Research
+slug: research
+---
+
+## Python for researchers
+
+If you are a working scientist, data scientist, digital humanities scholar or artist, then this part of the conference is just for you.
+Whether you have never used Python before and want to dip your toe in the water, or you are a fully-fledged Pythonista looking to expand your repertoire, the Code4Research theme will offer you three days of learning, collaboration and fun, and a chance to meet other researchers using Python.
+
+Now in its second year, the Code4Research theme will give you the chance to meet with and learn from fellow researchers and professional developers.
+Last year we were joined by Python programmers (and some non-programmers) from fields as diverse as mathematics, nuclear fusion and the digital humanities.
+[You can read about the fun we had, and why the 2015 delegates chose the theme name *Code4Research* here](http://www.software.ac.uk/blog/2015-09-30-event-research-software-engineers-starts-and-ends-bang-pycon-uk).
+
+Code4Research will run from Saturday 17th September -- Monday 19th:
+[Book now](/tickets/), [propose a session](/cfp/) or learn about [sponsorship opportunities](/sponsorship/).
+We are very keen to attract early career researchers, including MSc and PhD students, who should apply for [financial aid](/financial-aid/).
+
+TODO: embed ticket form here.
+
+More:
+
+ * [Last year's programme](http://2015.pyconuk.org/science/)
+ * [Software Sustainability Institute at PyCon UK 2015](http://www.software.ac.uk/blog/2015-09-30-event-research-software-engineers-starts-and-ends-bang-pycon-uk)


### PR DESCRIPTION
Fixes: https://github.com/PyconUK/pyconuk-2016-internaldocs/issues/52

Adds Code4Research page. Uses "theme" rather than "track". 

**Does not** include a link from the navigation bar.

@drvinceknight if you have a chance to give this the once-over that would be ace.
