### PR TITLE
Drop all unicode char escapes from templates

### DIFF
--- a/content/home.md
+++ b/content/home.md
@@ -11,34 +11,32 @@ from around the world.  This year, the conference is held at [Cardiff City
 Hall](http://www.cardiffcityhall.com/), from Thursday 15th to Monday 19th
 September.
 
-We&rsquo;ll be putting on a programme of talks, workshops, and other events
-aimed at the whole Python community, from web developers to hardware engineers,
-from professionals to hobbyists.  There will be an [education
-programme](/teachers/) for teachers, and an [expanded research
-programme](/research/) aimed at researchers from the humanities, arts and
-scientists.
+We'll be putting on a programme of talks, workshops, and other events aimed at
+the whole Python community, from web developers to hardware engineers, from
+professionals to hobbyists.  There will be an [education programme](/teachers/)
+for teachers, and an [expanded research programme](/research/) aimed at
+researchers from the humanities, arts and scientists.
 
-We&rsquo;re a community&hyphen;led, volunteer&hyphen;run conference, and this
-means we want you to be involved.  If you&rsquo;d like to give a talk or run a
-workshop, please see our [Call For Proposals](/cfp/).  We&rsquo;re particularly
-keen to hear from under&hyphen;represented groups and first&hyphen;time
-speakers.
+We're a community-led, volunteer-run conference, and this means we want you to
+be involved.  If you'd like to give a talk or run a workshop, please see our
+[Call For Proposals](/cfp/).  We're particularly keen to hear from
+under-represented groups and first-time speakers.
 
-Through the generosity of our sponsors, we&rsquo;re able to make the conference
-more affordable than in recent years, with individual [tickets](/tickets/) only
-&pound;96.  For the first time, we&rsquo;re also offering a [Financial Aid
+Through the generosity of our sponsors, we're able to make the conference more
+affordable than in recent years, with individual [tickets](/tickets/) only £96.
+For the first time, we're also offering a [Financial Aid
 Programme](/financial-aid/).
 
 PyCon UK cannot happen without sponsors.  If you or your company are interested
-in supporting the conference &mdash; perhaps you&rsquo;re recruiting, or sell
-to developers, or want to give something back to the community &mdash; take a
-look at our [sponsorship options](/sponsorship/).
+in supporting the conference — perhaps you're recruiting, or sell to
+developers, or want to give something back to the community — take a look at
+our [sponsorship options](/sponsorship/).
 
-We&rsquo;re committed to ensuring the conference is welcoming, enjoyable, and
-safe for everyone, and so we expect all attendees to agree to our [Code of
+We're committed to ensuring the conference is welcoming, enjoyable, and safe
+for everyone, and so we expect all attendees to agree to our [Code of
 Conduct](/code-of-conduct/).
 
-If you&rsquo;ve got any questions, [get in touch](/contact/).
+If you've got any questions, [get in touch](/contact/).
 
 We look forward to seeing you in September!
 

--- a/content/sponsorship.md
+++ b/content/sponsorship.md
@@ -9,10 +9,10 @@ Sponsoring PyCon UK is a great way for your company to support the Python
 community, promote your products, and meet Python developers who are looking
 for work.
 
-We couldn&rsquo;t run the conference without the generous support of our
-sponsors.  In return, we will ensure that our your company is given exposure
-before, during, and after the conference, and we will work with you so that you
-get exactly you&rsquo;re looking for out of sponsoring the conference.
+We couldn't run the conference without the generous support of our sponsors.
+In return, we will ensure that our your company is given exposure before,
+during, and after the conference, and we will work with you so that you get
+exactly you're looking for out of sponsoring the conference.
 
 
 ## Benefits
@@ -39,14 +39,13 @@ the programme to give a presentation about a topic of your choice.
 
 There are three available levels of sponsorship:
 
-* Gold sponsorship costs &pound;9,995.  You will be eligible for ten free
-tickets, and will be invited to give a fifteen-minute sponsored keynote on any
-appropriate topic during the conference.
-* Silver sponsorship costs &pound;4,995.  You will be eligible for five
-free tickets, and will be invited to give a five-minute sponsored lightning
-talk during the conference.
-* Bronze sponsorship costs &pound;1,995.  You will be eligible for two
-free tickets.
+* Gold sponsorship costs £9,995.  You will be eligible for ten free tickets,
+  and will be invited to give a fifteen-minute sponsored keynote on any
+  appropriate topic during the conference.
+* Silver sponsorship costs £4,995.  You will be eligible for five free tickets,
+  and will be invited to give a five-minute sponsored lightning talk during the
+  conference.
+* Bronze sponsorship costs £1,995.  You will be eligible for two free tickets.
 
 
 ## Corporate Social Responsibility
@@ -58,5 +57,5 @@ this is required.
 
 ## Next steps
 
-If you&rsquo;re interested in sponsoring the conference, please get in touch
-with us via email at pyconuk-sponsorship@python.org.
+If you're interested in sponsoring the conference, please get in touch with us
+via email at pyconuk-sponsorship@python.org.

--- a/content/teachers.md
+++ b/content/teachers.md
@@ -6,22 +6,21 @@ callout_big_2: Python in the classroom
 callout_small: Friday 16th September
 ---
 
-We&rsquo;re pleased to welcome teachers back to PyCon UK for a day of training,
+We're pleased to welcome teachers back to PyCon UK for a day of training,
 collaboration, and networking, in partnership with the Raspberry Pi Foundation.
 
-Now in its fifth year, PyCon UK&rsquo;s day for teachers gives teachers the
-chance to meet with and learn from developers, and developers the chance to
-share their expertise and contribute to the development of resources for the
-classroom.
+Now in its fifth year, PyCon UK's day for teachers gives teachers the chance to
+meet with and learn from developers, and developers the chance to share their
+expertise and contribute to the development of resources for the classroom.
 
-Once again, we&rsquo;re able to offer bursaries of **&pound;200 per teacher**,
-towards the cost of supply cover at school.
+Once again, we're able to offer bursaries of **£200 per teacher**, towards the
+cost of supply cover at school.
 
 Activities will include:
 
  * an introductory Python workshop;
- * &ldquo;Adopt a Teacher&rdquo;, for building long-term relationships between
-   teachers and developers;
+ * "Adopt a Teacher", for building long-term relationships between teachers and
+   developers;
  * workshops on using Python in the classroom with the micro:bit and Raspberry
    Pi;
  * a TeachMeet;
@@ -37,5 +36,5 @@ open by 1st May.
 
 More:
 
- * [Last year&rsquo;s programme](http://2015.pyconuk.org/education/#teachers)
+ * [Last year's programme](http://2015.pyconuk.org/education/#teachers)
  * [Raspberry Pi Foundation at PyCon UK 2015](https://www.raspberrypi.org/blog/kids-teachers-developers-pyconuk-2015/)

--- a/content/tickets.md
+++ b/content/tickets.md
@@ -6,10 +6,10 @@ tito_required: yes
 
 Tickets cost:
 
- * &pound;96 if you are paying for your own ticket;
- * &pound;144 if your employer is paying for your ticket.
+ * £96 if you are paying for your own ticket;
+ * £144 if your employer is paying for your ticket.
 
-Additionally, day tickets are available for &pound;36.
+Additionally, day tickets are available for £36.
 
 [Financial aid](/financial-aid/) is available to help cover ticket costs for
 those who would otherwise not be able to afford to attend the conference.


### PR DESCRIPTION
Since we have `<meta charset="utf-8">` in the base template these should be superfluous.
