### PR TITLE
Add details of financial assistance donations

### DIFF
--- a/content/diversity-accessibility.html
+++ b/content/diversity-accessibility.html
@@ -37,8 +37,8 @@ callout_big_1: You are a first-class citizen of our community
 
 <p><em>Don't be reluctant to apply for financial assistance.</em> Many of your fellow speakers and some members of the committee will be doing the same. The money is there to help <strong>you</strong>.</p>
 
-<h2>Supporter tickets</h2>
-<p>We have made <em>Supporter tickets</em> available. As well as your own ticket, you can buy a ticket on behalf of an attendee who couldn’t otherwise afford it. These tickets will be allocated by an awards committee, and you or your organisation will be - unless you state otherwise - thanked publicly for your generous support.</p>
+<h2>Donations towards financial assistance</h2>
+<p>When buying your own ticket, you can can make a donation to buy a ticket on behalf of an attendee who couldn’t otherwise afford it. These tickets will be allocated by an awards committee, and you or your organisation will be - unless you state otherwise - thanked publicly for your generous support.</p>
 
 <h2>Mobility</h2>
 

--- a/content/tickets.md
+++ b/content/tickets.md
@@ -13,8 +13,11 @@ Entrance to the day of introductory workshops on Thursday is free of charge.
 
 There are cheaper tickets if you can only come for some days, but we hope that you'll come for the whole conference!
 
-[Financial aid](/financial-aid/) is available to help cover ticket costs for
+[Financial assistance](/financial-aid/) is available to help cover ticket costs for
 those who would otherwise not be able to afford to attend the conference.
+
+When buying a ticket, you can make a donation towards our financial assistance budget.
+Every penny donated will be used to support the attendance of somebody who would otherwise find it hard to afford to come to the conference.
 
 Choose your ticket below:
 


### PR DESCRIPTION
This addresses https://github.com/PyconUK/pyconuk-2016-internaldocs/issues/84.

I have gone with "Donations towards financial assistance" over "Supporter tickets", since I felt that was easier to explain.

The donation field is now visible on the ticket form at http://2016.pyconuk.org/tickets/.
