### PR TITLE
Add separate Django Girls page

### DIFF
--- a/content/diversity-accessibility.html
+++ b/content/diversity-accessibility.html
@@ -18,13 +18,14 @@ callout_big_1: You are a first-class citizen of our community
 
 
 <h2>Django Girls</h2>
-<p>There'll be a day-long <a href="https://djangogirls.org/pyconuk2016/">Django Girls</a> workshop at PyCon UK. Since the first Django Girls event in July 2014, thousands of women have been introduced to Django and Python through these free workshops.</p>
+<p>There'll be a day-long <a href="/djangogirls/">Django Girls</a> workshop at PyCon UK. Since the first Django Girls event in July 2014, thousands of women have been introduced to Django and Python through these free workshops.</p>
 
 <p>Free conference tickets for PyCon UK will be given to DjangoGirls attendees. These are full tickets, and include lunches, refreshments and everything else that the conference has to offer.</p>
 
 <p>The workshop will be oversubscribed; places will be allocated by the Django Girls organisers.</p>
 
-<p><a href="https://djangogirls.org/pyconuk2016/apply/">Applications are open until July 29th</a>.</p>
+<p>To register your interest in attending, please <a href="https://djangogirls.org/pyconuk2016/apply/">fill in
+the application form</a>.</p>
 
 <h2>Trans*Code</h2>
 <p>Trans*Code will be running a hackday at the event.</p>

--- a/content/djangogirls.md
+++ b/content/djangogirls.md
@@ -1,0 +1,22 @@
+type: page
+title: Django Girls
+slug: djangogirls
+callout_big_1: Django Girls
+callout_big_2: Beginner-friendly Django workshop for women
+callout_small: Thursday 15th September.
+---
+
+[Django Girls](https://djangogirls.org/pyconuk2016/) is a one-day beginner friendly Python and Django workshop designed to inspire women to fall in love with programming.
+
+<iframe src="https://player.vimeo.com/video/112325567?byline=0" width="600" height="337" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+
+Since the first Django Girls event in July 2014, thousands of women have been introduced to Django and
+Python through these free workshops.
+
+Their mission is to bring more amazing women into the world of technology and increase the diversity of our community. They believe that technology is for people and everyone should be able to build it. They make technology more approachable by creating simple tools and resources designed with empathy.
+
+Free conference tickets for PyCon UK will be given to DjangoGirls attendees. These are full tickets, and include lunches, refreshments and everything else that the conference has to offer.
+
+The workshop will be oversubscribed; places will be allocated by the Django Girls organisers.
+
+To register your interest in attending, please [fill in the application form](https://djangogirls.org/pyconuk2016/apply/).


### PR DESCRIPTION
This is partly taken from last year's page.
- Link there from diversity page
- Remove application deadline from diversity page since we might move it again, it is easier if we can just take the link down when we finally close applications.
