### PR TITLE
Improve the appearance of pages on narrow screens

### DIFF
--- a/media/less/styles.less
+++ b/media/less/styles.less
@@ -561,8 +561,10 @@ label[for='primary-nav'] {
 //////////////////////    TEMPLATE BLOCKS        /////////////////////
 
 .intro, .content {
-    width: 42.5em;
+    max-width: 42.5em;
     margin: auto;
+    padding-left:  15px;
+    padding-right: 15px;
     body.single-col & {
         @media all and (max-width: 43.75em) {
             width: 100%;
@@ -1253,15 +1255,19 @@ body.two-col & {
   td {
     text-align: center;
     vertical-align: middle;
-    padding: 5px;
+    padding: 8px;
   }
 
   .logo {
-    width: 240px;
+    width: 50%;
   }
 
   .wide-logo {
-    width: 480px;
+    width: 100%;
+  }
+
+  .logo img, .wide-logo img {
+    width: 100%;
   }
 }
 

--- a/templates/page.html
+++ b/templates/page.html
@@ -36,14 +36,14 @@
       <hr />
 
       <div class="sponsors-list">
-        <h3>The conference wouldn't happen without the support of our sponsors:<h3>
+        <h3>The conference wouldn't happen without the support of our sponsors:</h3>
         <table>
           {% for row in sponsor_table %}
           <tr>
             {% for sponsor in row %}
-            <td colspan="{% if row|length == 1 %}2{% else %}1{% endif %}">
+            <td colspan="{% if row|length == 1 %}2{% else %}1{% endif %}" class="{% if row|length == 1 %}wide-logo{% else %}logo{% endif %}">
               <a href="{% if sponsor.content %}/sponsors/{{ sponsor.key }}/{% else %}#{% endif %}">
-                <img src="/static/img/logos/{{ sponsor.logo_filename }}" class="{% if row|length == 1 %}wide-logo{% else %}logo{% endif %}" />
+                <img src="/static/img/logos/{{ sponsor.logo_filename }}" />
               </a>
             </td>
             {% endfor %}


### PR DESCRIPTION
Main goal is to stop the content disappearing off into the margin and forcing people to scroll horizontally. Built and tested locally.

This is what the new version looks like:

![screen shot 2016-08-22 at 21 09 41](https://cloud.githubusercontent.com/assets/301220/17869937/50024a92-68ad-11e6-847d-6d3b6b8d9430.png)
![screen shot 2016-08-22 at 21 09 47](https://cloud.githubusercontent.com/assets/301220/17869938/5037ea58-68ad-11e6-8c51-ec8c6e7fc3cb.png)
![screen shot 2016-08-22 at 21 12 01](https://cloud.githubusercontent.com/assets/301220/17869939/5038e552-68ad-11e6-89be-e28be8810009.png)
