### PR TITLE
Update teachers day page

### DIFF
--- a/pages/teachers.md
+++ b/pages/teachers.md
@@ -1,6 +1,6 @@
 title: Teachers at PyCon UK
 callout_big_1: A one-day mini-conference about
-callout_big_2: Python in the classroom
+callout_big_2: Python in Education
 callout_small: Friday 16th September
 ---
 
@@ -11,23 +11,34 @@ Now in its fifth year, PyCon UK's day for teachers gives teachers the chance to
 meet with and learn from developers, and developers the chance to share their
 expertise and contribute to the development of resources for the classroom.
 
+Whatever your experience with programming and python, there is a session for you. 
+
 Once again, we're able to offer [bursaries](/teachers/bursaries/) of **£200 per
-teacher**, towards the cost of supply cover at school.
+teacher**, towards the cost of supply cover at school so that you can attend. Check out the great event we have planned for you. 
 
-Activities will include:
+### Teacher workshops:
 
- * an introductory Python workshop;
- * "Adopt a Teacher", for building long-term relationships between teachers and
-   developers;
- * workshops on using Python in the classroom with the micro:bit and Raspberry
-   Pi;
- * a TeachMeet;
- * ...and a lot more!
+ * Learn the stepping stones to text-based programming in an introductory Python workshop with [Rik Cross](https://twitter.com/CodeClubRik) and Tracy Gardner from [Code Club](https://www.codeclub.org.uk/)
+ * Moving students from Scratch to Python with experienced primary school teacher [Sway Grantham](http://swaygrantham.co.uk/)
+ * Did you know that with Python and Raspberry Pi you can hack Minecraft? Learn how to engage students in Computing with experienced teacher and Computng At School Manchester regional centres' very own [Sarah Zaman](https://twitter.com/sezzyann72).
+ * Learn how to make games with [Pygame Zero](http://mauveweb.co.uk/posts/2015/05/pygame-zero.html), a way of using Python to teach game development lead by experienced teacher and trainer [Dave Ames](https://twitter.com/davidames?lang=en-gb). 
+ * Know some Python basics? Why not take the next steps by learning about modules, functions and classes with author, Minecraft expert and teacher trainer [Martin O'Hanlon](http://www.stuffaboutcode.com/). 
+ * Get physical with computing on a Raspberry Pi and control real world objects with Python code. A session brough to you by Picademy Manager [James Robinson](https://twitter.com/legojames), Content and Curriculum Manager [Marc Scott](https://twitter.com/Coding2Learn) and Community Manager [Ben Nuttall](https://twitter.com/ben_nuttall) from the [Raspberry Pi Foundation](http://raspberrypi.org/education).
+ * Do you have BBC Micro:bits? Learn how to make the most of them using MicroPython with ex-teacher turned developer and all round good-guy [Nicholas Tollervey](http://ntoll.org/).
 
-Teachers are invited to come for the whole weekend and take part in the main
-conference, where there will be sessions and activities aimed at all Python
-programmers of all backgrounds and abilities.  Day tickets are available for
-those who are only able to come for one day.
+### Networking opportunties: 
+
+ * "Adopt a Developer" because PyconUK professional development is not just for one day. Building long-term relationships between teachers and developers to support your journey with Python is for life!
+ * a TeachMeet. Your chance to share what you've been doing in your classroom with others. 
+ * All aboard the big classroom bus to have some hacking time on a Raspberry Pi with some Python projects. 
+
+### Talks:
+
+ * There will be talks in the main conference from teachers [Laura Dixon](https://codeboom.wordpress.com/) and [Cat Lamin](https://teachprimarycomputing.wordpress.com/). 
+ * And a talk about [GPIO Zero](https://www.raspberrypi.org/magpi/gpio-zero-essentials/), a python library that helps teach physical computing to young people from Ben Nuttall. 
+
+All of this great professional development in one day! Day tickets are available but educators are invited to come for the whole weekend and take part in the main conference too, where there will be sessions and activities aimed at all Python
+programmers of all backgrounds and abilities. 
 
 [Tickets are on sale now!](/tickets/)
 

--- a/pages/teachers.md
+++ b/pages/teachers.md
@@ -31,6 +31,7 @@ teacher**, towards the cost of supply cover at school so that you can attend. Ch
  * "Adopt a Developer" because PyconUK professional development is not just for one day. Building long-term relationships between teachers and developers to support your journey with Python is for life!
  * a TeachMeet. Your chance to share what you've been doing in your classroom with others. 
  * All aboard the big classroom bus to have some hacking time on a Raspberry Pi with some Python projects. 
+ * Join a community of educators and developers interested in Python in Education through the [Python Software Foundation's working group](https://wiki.python.org/psf/PythonEduWG) 
 
 ### Talks:
 


### PR DESCRIPTION
Update teachers day page with information on workshops, networking and talks. Include information about the speakers and session leaders. 
