### PR TITLE
Speaker: Paul Walsh

### DIFF
--- a/sessions/workshops/small-projects-ideas-with-open-data-using-python.md
+++ b/sessions/workshops/small-projects-ideas-with-open-data-using-python.md
@@ -1,4 +1,15 @@
-title: Small projects ideas with open data using Python
+title: Open Data projects with Python
 speaker: paul-walsh
 ---
-When people are just starting out to code, it can be hard define a small project or goal with outputs to learn through. Doing so provides direction and scope for learning and exploration. I'll introduce beginner programmers to the world of open data, and discuss some simple project ideas using open data as a way to dive into either (or both) data wrangling and analysis, and building web apps.
+
+This is a workshop targeted at beginners, and introduces an applied approach to solving problems with code, using [Open Data](https://en.wikipedia.org/wiki/Open_data).
+
+This workshop starts from the assumption that small projects related to real-world issues can provide direction and scope for learning and exploration. With a few simple tools in Python, and access to a range of Open Data sources, we can ask some questions about the socio-political context we live in, and move towards answers to those questions.
+
+We'll take a narrative approach to this, using [Jupyter Notebooks](http://jupyter-notebook-beginner-guide.readthedocs.io/en/latest/what_is_jupyter.html) as our problem-solving environment, which requires less overhead than full stack development tooling, and allows us to focus on the content of our exploration, rather than code design and architecture.
+
+In addition to walking through some simple examples, we'll discuss other project ideas that can be pursued with Python, Open Data, and an inquisitive mind!
+
+The workshop will have a set of Jupyter Notebooks with simple, real world examples of common code we need to write to work with and gain insights out of Open Data. While not strictly required for workshop attendance, it will be useful to have these set up on your machine to follow along. For this, you'll need to have [Python 3](https://www.python.org/downloads/) and [Jupyter](http://jupyter.org) installed in advance.
+
+The Notebooks for the workshop will be [published here](https://github.com/pwalsh/notebooks/tree/master/opendataprojects) the day prior.

--- a/speakers/paul-walsh.md
+++ b/speakers/paul-walsh.md
@@ -1,3 +1,4 @@
 name: Paul Walsh
 ---
-I'm Head of Technical Product at Open Knowledge International
+
+Paul is Head of Technical Product at Open Knowledge International, a non-profit dedicated to openness and transparency through open data. Paul oversees platforms like [OpenTrials](http://opentrials.net) and [OpenSpending](http://next.openspending.org), and the wide range of [open source code](https://github.com/okfn) and [specification work](https://github.com/frictionlessdata/specs) that Open Knowledge International collaborates on with the open data community. [Read more](http://pwalsh.me).

--- a/speakers/paul-walsh.md
+++ b/speakers/paul-walsh.md
@@ -1,4 +1,4 @@
 name: Paul Walsh
 ---
 
-Paul is Head of Technical Product at Open Knowledge International, a non-profit dedicated to openness and transparency through open data. Paul oversees platforms like [OpenTrials](http://opentrials.net) and [OpenSpending](http://next.openspending.org), and the wide range of [open source code](https://github.com/okfn) and [specification work](https://github.com/frictionlessdata/specs) that Open Knowledge International collaborates on with the open data community. [Read more](http://pwalsh.me).
+Paul is Head of Technical Product at [Open Knowledge International](https://okfn.org), a non-profit dedicated to openness and transparency through open data. Paul oversees platforms like [OpenTrials](http://opentrials.net) and [OpenSpending](http://next.openspending.org), and the wide range of [open source code](https://github.com/okfn) and [specification work](https://github.com/frictionlessdata/specs) that Open Knowledge International collaborates on with the open data community. [Read more](http://pwalsh.me).


### PR DESCRIPTION
This pull request updates Paul Walsh's bio, and the description of his workshop.

**Note**: I'd also like to have changed the URL for the workshop, to reflect the change in title, but it is unclear (to me) how django-amber handles redirects, and the examples in the current codebase only handle redirects from the top-level directory of the domain.
