### PR TITLE
Reschedule the /schedule page

### DIFF
--- a/pyconuk/views/__init__.py
+++ b/pyconuk/views/__init__.py
@@ -327,6 +327,7 @@ def unlinked_pages_view(request):
         '/session-chairs/',
         '/calendar/',
         '/microbit/',
+        '/schedule/',
     ]
 
     for redirection in Redirection.objects.order_by('key'):


### PR DESCRIPTION
There's a comment in `urls.py` about the `/schedule` slug that says:

``` python
# We need to keep this URL since it is referenced on visa invitation letters
```

but http://2016.pyconuk.org/schedule/ is 404'ing, because it isn't actually linked from anywhere.  Oops.
